### PR TITLE
add result to request object as well

### DIFF
--- a/IndexedDB-getAll-shim.js
+++ b/IndexedDB-getAll-shim.js
@@ -58,6 +58,7 @@
                         readyState: "done",
                         result: result
                     };
+                    request.result = result;
                     request.onsuccess(e);
                 }
             }


### PR DESCRIPTION
In addition to being able to access the result of a _mozGetAll_ call via the _event.target.result_ property, you can also access it via the _result_ property of the _request_ object, so this branch adds the _result_ to the _request_ object.
